### PR TITLE
More resilient gpg getting

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -4,8 +4,9 @@ FROM debian:wheezy
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
-	&& echo 'deb http://repo.percona.com/apt wheezy main' > /etc/apt/sources.list.d/percona.list
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A
+
+RUN echo 'deb http://repo.percona.com/apt wheezy main' > /etc/apt/sources.list.d/percona.list
 
 ENV PERCONA_MAJOR 5.5
 ENV PERCONA_VERSION 5.5.42-rel37.1-1.wheezy

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -4,8 +4,9 @@ FROM debian:wheezy
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
-	&& echo 'deb http://repo.percona.com/apt wheezy main' > /etc/apt/sources.list.d/percona.list
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A
+
+RUN echo 'deb http://repo.percona.com/apt wheezy main' > /etc/apt/sources.list.d/percona.list
 
 ENV PERCONA_MAJOR 5.6
 ENV PERCONA_VERSION 5.6.23-72.1-1.wheezy

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,8 +4,9 @@ FROM debian:wheezy
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-RUN apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
-	&& echo 'deb http://repo.percona.com/apt wheezy main' > /etc/apt/sources.list.d/percona.list
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A
+
+RUN echo 'deb http://repo.percona.com/apt wheezy main' > /etc/apt/sources.list.d/percona.list
 
 ENV PERCONA_MAJOR %%PERCONA_MAJOR%%
 ENV PERCONA_VERSION %%PERCONA_VERSION%%


### PR DESCRIPTION
- move to "high-availability" [subset](https://sks-keyservers.net/overview-of-pools.php#pool_ha).

related: https://github.com/docker-library/php/pull/92
