### PR TITLE
Make /var/log/mysql (binary logs) persistent

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -32,7 +32,7 @@ RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/my.cnf \
 	&& echo 'skip-host-cache\nskip-name-resolve' | awk '{ print } $1 == "[mysqld]" && c == 0 { c = 1; system("cat") }' /etc/mysql/my.cnf > /tmp/my.cnf \
 	&& mv /tmp/my.cnf /etc/mysql/my.cnf
 
-VOLUME /var/lib/mysql
+VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 
 COPY docker-entrypoint.sh /
 

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -32,7 +32,7 @@ RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/my.cnf \
 	&& echo 'skip-host-cache\nskip-name-resolve' | awk '{ print } $1 == "[mysqld]" && c == 0 { c = 1; system("cat") }' /etc/mysql/my.cnf > /tmp/my.cnf \
 	&& mv /tmp/my.cnf /etc/mysql/my.cnf
 
-VOLUME /var/lib/mysql
+VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 
 COPY docker-entrypoint.sh /
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -32,7 +32,7 @@ RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/my.cnf \
 	&& echo 'skip-host-cache\nskip-name-resolve' | awk '{ print } $1 == "[mysqld]" && c == 0 { c = 1; system("cat") }' /etc/mysql/my.cnf > /tmp/my.cnf \
 	&& mv /tmp/my.cnf /etc/mysql/my.cnf
 
-VOLUME /var/lib/mysql
+VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 
 COPY docker-entrypoint.sh /
 


### PR DESCRIPTION
Binary logs are stored by default in `/var/log/mysql`

Since`/var/lib/mysql` is persistent, binary logs also need to be persistent to keep a coherent set of data.
