### PR TITLE
character set/collation options for MYSQL_DATABASE creation

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -131,14 +131,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		file_env 'MYSQL_DATABASE'
 		if [ "$MYSQL_DATABASE" ]; then
-		    database_defaults=""
-		    if [ "$MYSQL_DATABASE_CHARACTER_SET" ]; then
-		        database_defaults+=" DEFAULT CHARACTER SET $MYSQL_DATABASE_CHARACTER_SET"
-		    fi
-		    if [ "$MYSQL_DATABASE_COLLATION" ]; then
-		        database_defaults+=" DEFAULT COLLATE $MYSQL_DATABASE_COLLATION"
-		    fi
-			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` $database_defaults;" | "${mysql[@]}"
+			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ${MYSQL_DATABASE_CHARACTER_SET:+DEFAULT CHARACTER SET $MYSQL_DATABASE_CHARACTER_SET} ${MYSQL_DATABASE_COLLATION:+DEFAULT COLLATE $MYSQL_DATABASE_COLLATION};" | "${mysql[@]}"
 			mysql+=( "$MYSQL_DATABASE" )
 		fi
 

--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -131,7 +131,14 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		file_env 'MYSQL_DATABASE'
 		if [ "$MYSQL_DATABASE" ]; then
-			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" | "${mysql[@]}"
+		    database_defaults=""
+		    if [ "$MYSQL_DATABASE_CHARACTER_SET" ]; then
+		        database_defaults+=" DEFAULT CHARACTER SET $MYSQL_DATABASE_CHARACTER_SET"
+		    fi
+		    if [ "$MYSQL_DATABASE_COLLATION" ]; then
+		        database_defaults+=" DEFAULT COLLATE $MYSQL_DATABASE_COLLATION"
+		    fi
+			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` $database_defaults;" | "${mysql[@]}"
 			mysql+=( "$MYSQL_DATABASE" )
 		fi
 

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -131,14 +131,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		file_env 'MYSQL_DATABASE'
 		if [ "$MYSQL_DATABASE" ]; then
-		    database_defaults=""
-		    if [ "$MYSQL_DATABASE_CHARACTER_SET" ]; then
-		        database_defaults+=" DEFAULT CHARACTER SET $MYSQL_DATABASE_CHARACTER_SET"
-		    fi
-		    if [ "$MYSQL_DATABASE_COLLATION" ]; then
-		        database_defaults+=" DEFAULT COLLATE $MYSQL_DATABASE_COLLATION"
-		    fi
-			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` $database_defaults;" | "${mysql[@]}"
+			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ${MYSQL_DATABASE_CHARACTER_SET:+DEFAULT CHARACTER SET $MYSQL_DATABASE_CHARACTER_SET} ${MYSQL_DATABASE_COLLATION:+DEFAULT COLLATE $MYSQL_DATABASE_COLLATION};" | "${mysql[@]}"
 			mysql+=( "$MYSQL_DATABASE" )
 		fi
 

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -131,7 +131,14 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		file_env 'MYSQL_DATABASE'
 		if [ "$MYSQL_DATABASE" ]; then
-			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" | "${mysql[@]}"
+		    database_defaults=""
+		    if [ "$MYSQL_DATABASE_CHARACTER_SET" ]; then
+		        database_defaults+=" DEFAULT CHARACTER SET $MYSQL_DATABASE_CHARACTER_SET"
+		    fi
+		    if [ "$MYSQL_DATABASE_COLLATION" ]; then
+		        database_defaults+=" DEFAULT COLLATE $MYSQL_DATABASE_COLLATION"
+		    fi
+			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` $database_defaults;" | "${mysql[@]}"
 			mysql+=( "$MYSQL_DATABASE" )
 		fi
 

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -131,14 +131,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		file_env 'MYSQL_DATABASE'
 		if [ "$MYSQL_DATABASE" ]; then
-		    database_defaults=""
-		    if [ "$MYSQL_DATABASE_CHARACTER_SET" ]; then
-		        database_defaults+=" DEFAULT CHARACTER SET $MYSQL_DATABASE_CHARACTER_SET"
-		    fi
-		    if [ "$MYSQL_DATABASE_COLLATION" ]; then
-		        database_defaults+=" DEFAULT COLLATE $MYSQL_DATABASE_COLLATION"
-		    fi
-			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` $database_defaults;" | "${mysql[@]}"
+			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ${MYSQL_DATABASE_CHARACTER_SET:+DEFAULT CHARACTER SET $MYSQL_DATABASE_CHARACTER_SET} ${MYSQL_DATABASE_COLLATION:+DEFAULT COLLATE $MYSQL_DATABASE_COLLATION};" | "${mysql[@]}"
 			mysql+=( "$MYSQL_DATABASE" )
 		fi
 

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -131,7 +131,14 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		file_env 'MYSQL_DATABASE'
 		if [ "$MYSQL_DATABASE" ]; then
-			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" | "${mysql[@]}"
+		    database_defaults=""
+		    if [ "$MYSQL_DATABASE_CHARACTER_SET" ]; then
+		        database_defaults+=" DEFAULT CHARACTER SET $MYSQL_DATABASE_CHARACTER_SET"
+		    fi
+		    if [ "$MYSQL_DATABASE_COLLATION" ]; then
+		        database_defaults+=" DEFAULT COLLATE $MYSQL_DATABASE_COLLATION"
+		    fi
+			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` $database_defaults;" | "${mysql[@]}"
 			mysql+=( "$MYSQL_DATABASE" )
 		fi
 


### PR DESCRIPTION
This PR adds the two environment variables **MYSQL_DATABASE_CHARACTER_SET** and **MYSQL_DATABASE_COLLATION**.
They can be used to set the default character set and default collation of the optionally created database (triggered via the existing **MYSQL_DATABASE** environment variable). Both environment variables are completely optional.