### PR TITLE
Move docker-specific [mysqld] additions to their own "docker.cnf" file

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -76,12 +76,7 @@ RUN \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \
 		| xargs -0 sed -Ei 's/^(bind-address|log)/#&/' \
-	&& myCnf="$(find /etc/mysql/ -name '*.cnf' -print0 \
-		| xargs -0 grep -lE '^\[mysqld\]' \
-		| head -n1)" \
-	&& echo 'skip-host-cache\nskip-name-resolve' \
-		| awk '{ print } $1 == "[mysqld]" && c == 0 { c = 1; system("cat") }' "$myCnf" > /tmp/my.cnf \
-	&& mv /tmp/my.cnf "$myCnf"
+	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -76,12 +76,7 @@ RUN \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \
 		| xargs -0 sed -Ei 's/^(bind-address|log)/#&/' \
-	&& myCnf="$(find /etc/mysql/ -name '*.cnf' -print0 \
-		| xargs -0 grep -lE '^\[mysqld\]' \
-		| head -n1)" \
-	&& echo 'skip-host-cache\nskip-name-resolve' \
-		| awk '{ print } $1 == "[mysqld]" && c == 0 { c = 1; system("cat") }' "$myCnf" > /tmp/my.cnf \
-	&& mv /tmp/my.cnf "$myCnf"
+	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -76,12 +76,7 @@ RUN \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \
 		| xargs -0 sed -Ei 's/^(bind-address|log)/#&/' \
-	&& myCnf="$(find /etc/mysql/ -name '*.cnf' -print0 \
-		| xargs -0 grep -lE '^\[mysqld\]' \
-		| head -n1)" \
-	&& echo 'skip-host-cache\nskip-name-resolve' \
-		| awk '{ print } $1 == "[mysqld]" && c == 0 { c = 1; system("cat") }' "$myCnf" > /tmp/my.cnf \
-	&& mv /tmp/my.cnf "$myCnf"
+	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -76,12 +76,7 @@ RUN \
 	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \
 		| xargs -0 sed -Ei 's/^(bind-address|log)/#&/' \
-	&& myCnf="$(find /etc/mysql/ -name '*.cnf' -print0 \
-		| xargs -0 grep -lE '^\[mysqld\]' \
-		| head -n1)" \
-	&& echo 'skip-host-cache\nskip-name-resolve' \
-		| awk '{ print } $1 == "[mysqld]" && c == 0 { c = 1; system("cat") }' "$myCnf" > /tmp/my.cnf \
-	&& mv /tmp/my.cnf "$myCnf"
+	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 


### PR DESCRIPTION
Duplicating the change of https://github.com/docker-library/mysql/pull/232 and https://github.com/docker-library/mariadb/pull/115.