### PR TITLE
Resync changes from mysql/mariadb: improve bind-address comment out, add `MYSQL_ROOT_HOST` support

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -74,14 +74,12 @@ RUN { \
 	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
 	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
 # ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 777 /var/run/mysqld
-
+	&& chmod 777 /var/run/mysqld \
 # comment out a few problematic configuration values
-# don't reverse lookup hostnames, they are usually another container
-RUN \
-	find /etc/mysql/ -name '*.cnf' -print0 \
+	&& find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \
-		| xargs -0 sed -Ei 's/^(bind-address|log)/#&/' \
+		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/' \
+# don't reverse lookup hostnames, they are usually another container
 	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -74,14 +74,12 @@ RUN { \
 	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
 	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
 # ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 777 /var/run/mysqld
-
+	&& chmod 777 /var/run/mysqld \
 # comment out a few problematic configuration values
-# don't reverse lookup hostnames, they are usually another container
-RUN \
-	find /etc/mysql/ -name '*.cnf' -print0 \
+	&& find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \
-		| xargs -0 sed -Ei 's/^(bind-address|log)/#&/' \
+		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/' \
+# don't reverse lookup hostnames, they are usually another container
 	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -74,14 +74,12 @@ RUN { \
 	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
 	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
 # ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 777 /var/run/mysqld
-
+	&& chmod 777 /var/run/mysqld \
 # comment out a few problematic configuration values
-# don't reverse lookup hostnames, they are usually another container
-RUN \
-	find /etc/mysql/ -name '*.cnf' -print0 \
+	&& find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \
-		| xargs -0 sed -Ei 's/^(bind-address|log)/#&/' \
+		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/' \
+# don't reverse lookup hostnames, they are usually another container
 	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -74,14 +74,12 @@ RUN { \
 	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
 	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
 # ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 777 /var/run/mysqld
-
+	&& chmod 777 /var/run/mysqld \
 # comment out a few problematic configuration values
-# don't reverse lookup hostnames, they are usually another container
-RUN \
-	find /etc/mysql/ -name '*.cnf' -print0 \
+	&& find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \
-		| xargs -0 sed -Ei 's/^(bind-address|log)/#&/' \
+		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/' \
+# don't reverse lookup hostnames, they are usually another container
 	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]


### PR DESCRIPTION
See also https://github.com/docker-library/mysql/pull/336 and https://github.com/docker-library/mysql/pull/249