### PR TITLE
Docker build fail because docker-entrypoint.sh file permissions

### DIFF
--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -85,7 +85,8 @@ RUN { \
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN ln -s /usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 3306


### PR DESCRIPTION
When I used docker build, the docker-entrypoint.sh file was rendered unusable due to insufficient permissions, and I fixed it with two lines of commands.

Please check and merge, thanks!