### PR TITLE
Add arches supported by upstream percona (i386), add suite tags for `jessie` (so we can move to `stretch`)

### DIFF
--- a/.architectures-lib
+++ b/.architectures-lib
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+hasBashbrewArch() {
+	local version="$1"; shift
+	local bashbrewArch="$1"; shift
+	local arches="$(grep 'bashbrew-architectures:' "$version/Dockerfile" | cut -d':' -f2)"
+	[[ " $arches " == *" $bashbrewArch "* ]]
+}
+
+_generateParentRepoToArches() {
+	local repo="$1"; shift
+	local officialImagesUrl='https://github.com/docker-library/official-images/raw/master/library/'
+
+	eval "declare -g -A parentRepoToArches=( $(
+		find -name 'Dockerfile' -exec awk '
+				toupper($1) == "FROM" && $2 !~ /^('"$repo"'|scratch|microsoft\/[^:]+)(:|$)/ {
+					print "'"$officialImagesUrl"'" $2
+				}
+			' '{}' + \
+			| sort -u \
+			| xargs bashbrew cat --format '[{{ .RepoName }}:{{ .TagName }}]="{{ join " " .TagEntry.Architectures }}"'
+	) )"
+}
+_generateParentRepoToArches 'percona'
+
+parentArches() {
+	local version="$1"; shift # "1.8", etc
+
+	local parent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/Dockerfile")"
+	echo "${parentRepoToArches[$parent]:-}"
+}
+versionArches() {
+	local version="$1"; shift # "1.8", etc
+
+	local parentArches="$(parentArches "$version")"
+
+	local variantArches=()
+	for arch in $parentArches; do
+		if hasBashbrewArch "$version" "$arch"; then
+			variantArches+=( "$arch" )
+		fi
+	done
+	echo "${variantArches[*]}"
+}

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -4,24 +4,52 @@ FROM debian:jessie
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
+# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
+RUN set -ex; \
+	apt-get update; \
+	if ! which gpg; then \
+		apt-get install -y --no-install-recommends gnupg; \
+	fi; \
+# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
+# so, if we're not running gnupg 1.x, explicitly install dirmngr too
+	if ! gpg --version | grep -q '^gpg (GnuPG) 1\.'; then \
+		 apt-get install -y --no-install-recommends dirmngr; \
+	fi; \
+	rm -rf /var/lib/apt/lists/*
+
 # add gosu for easy step-down from root
-ENV GOSU_VERSION 1.7
-RUN set -x \
-	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
-	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu \
-	&& gosu nobody true \
-	&& apt-get purge -y --auto-remove ca-certificates wget
+ENV GOSU_VERSION 1.10
+RUN set -ex; \
+	\
+	fetchDeps=' \
+		ca-certificates \
+		wget \
+	'; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends $fetchDeps; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	command -v gpgconf > /dev/null && gpgconf --kill all || :; \
+	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu nobody true; \
+	\
+	apt-get purge -y --auto-remove $fetchDeps
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "pwgen" for randomizing passwords
 # install "apt-transport-https" for Percona's repo (switched to https-only)
+# install "pwgen" for randomizing passwords
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		apt-transport-https ca-certificates \
 		pwgen \
@@ -44,17 +72,20 @@ RUN set -ex; \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done; \
 	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/percona.gpg; \
+	command -v gpgconf > /dev/null && gpgconf --kill all || :; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
 RUN echo 'deb https://repo.percona.com/apt jessie main' > /etc/apt/sources.list.d/percona.list
 
+# bashbrew-architectures: amd64 i386
 ENV PERCONA_MAJOR 5.5
 ENV PERCONA_VERSION 5.5.60-rel38.12-1.jessie
 
 # the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
 # also, we set debconf keys to make APT a little quieter
-RUN { \
+RUN set -ex; \
+	{ \
 		for key in \
 			percona-server-server/root_password \
 			percona-server-server/root_password_again \
@@ -63,24 +94,26 @@ RUN { \
 		; do \
 			echo "percona-server-server-$PERCONA_MAJOR" "$key" password 'unused'; \
 		done; \
-	} | debconf-set-selections \
-	&& apt-get update \
-	&& apt-get install -y \
+	} | debconf-set-selections; \
+	apt-get update; \
+	apt-get install -y \
 		percona-server-server-$PERCONA_MAJOR=$PERCONA_VERSION \
-	&& rm -rf /var/lib/apt/lists/* \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)
-	&& sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf \
+	sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf; \
 # purge and re-create /var/lib/mysql with appropriate ownership
-	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
-	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
+	rm -rf /var/lib/mysql; \
+	mkdir -p /var/lib/mysql /var/run/mysqld; \
+	chown -R mysql:mysql /var/lib/mysql /var/run/mysqld; \
 # ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 777 /var/run/mysqld \
+	chmod 777 /var/run/mysqld; \
 # comment out a few problematic configuration values
-	&& find /etc/mysql/ -name '*.cnf' -print0 \
+	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \
-		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/' \
+		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/'; \
 # don't reverse lookup hostnames, they are usually another container
-	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
+	echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -4,24 +4,52 @@ FROM debian:jessie
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
+# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
+RUN set -ex; \
+	apt-get update; \
+	if ! which gpg; then \
+		apt-get install -y --no-install-recommends gnupg; \
+	fi; \
+# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
+# so, if we're not running gnupg 1.x, explicitly install dirmngr too
+	if ! gpg --version | grep -q '^gpg (GnuPG) 1\.'; then \
+		 apt-get install -y --no-install-recommends dirmngr; \
+	fi; \
+	rm -rf /var/lib/apt/lists/*
+
 # add gosu for easy step-down from root
-ENV GOSU_VERSION 1.7
-RUN set -x \
-	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
-	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu \
-	&& gosu nobody true \
-	&& apt-get purge -y --auto-remove ca-certificates wget
+ENV GOSU_VERSION 1.10
+RUN set -ex; \
+	\
+	fetchDeps=' \
+		ca-certificates \
+		wget \
+	'; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends $fetchDeps; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	command -v gpgconf > /dev/null && gpgconf --kill all || :; \
+	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu nobody true; \
+	\
+	apt-get purge -y --auto-remove $fetchDeps
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "pwgen" for randomizing passwords
 # install "apt-transport-https" for Percona's repo (switched to https-only)
+# install "pwgen" for randomizing passwords
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		apt-transport-https ca-certificates \
 		pwgen \
@@ -44,17 +72,20 @@ RUN set -ex; \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done; \
 	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/percona.gpg; \
+	command -v gpgconf > /dev/null && gpgconf --kill all || :; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
 RUN echo 'deb https://repo.percona.com/apt jessie main' > /etc/apt/sources.list.d/percona.list
 
+# bashbrew-architectures: amd64 i386
 ENV PERCONA_MAJOR 5.6
 ENV PERCONA_VERSION 5.6.40-84.0-1.jessie
 
 # the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
 # also, we set debconf keys to make APT a little quieter
-RUN { \
+RUN set -ex; \
+	{ \
 		for key in \
 			percona-server-server/root_password \
 			percona-server-server/root_password_again \
@@ -63,24 +94,26 @@ RUN { \
 		; do \
 			echo "percona-server-server-$PERCONA_MAJOR" "$key" password 'unused'; \
 		done; \
-	} | debconf-set-selections \
-	&& apt-get update \
-	&& apt-get install -y \
+	} | debconf-set-selections; \
+	apt-get update; \
+	apt-get install -y \
 		percona-server-server-$PERCONA_MAJOR=$PERCONA_VERSION \
-	&& rm -rf /var/lib/apt/lists/* \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)
-	&& sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf \
+	sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf; \
 # purge and re-create /var/lib/mysql with appropriate ownership
-	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
-	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
+	rm -rf /var/lib/mysql; \
+	mkdir -p /var/lib/mysql /var/run/mysqld; \
+	chown -R mysql:mysql /var/lib/mysql /var/run/mysqld; \
 # ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 777 /var/run/mysqld \
+	chmod 777 /var/run/mysqld; \
 # comment out a few problematic configuration values
-	&& find /etc/mysql/ -name '*.cnf' -print0 \
+	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \
-		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/' \
+		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/'; \
 # don't reverse lookup hostnames, they are usually another container
-	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
+	echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -4,24 +4,52 @@ FROM debian:jessie
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
+# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
+RUN set -ex; \
+	apt-get update; \
+	if ! which gpg; then \
+		apt-get install -y --no-install-recommends gnupg; \
+	fi; \
+# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
+# so, if we're not running gnupg 1.x, explicitly install dirmngr too
+	if ! gpg --version | grep -q '^gpg (GnuPG) 1\.'; then \
+		 apt-get install -y --no-install-recommends dirmngr; \
+	fi; \
+	rm -rf /var/lib/apt/lists/*
+
 # add gosu for easy step-down from root
-ENV GOSU_VERSION 1.7
-RUN set -x \
-	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
-	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu \
-	&& gosu nobody true \
-	&& apt-get purge -y --auto-remove ca-certificates wget
+ENV GOSU_VERSION 1.10
+RUN set -ex; \
+	\
+	fetchDeps=' \
+		ca-certificates \
+		wget \
+	'; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends $fetchDeps; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	command -v gpgconf > /dev/null && gpgconf --kill all || :; \
+	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu nobody true; \
+	\
+	apt-get purge -y --auto-remove $fetchDeps
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "pwgen" for randomizing passwords
 # install "apt-transport-https" for Percona's repo (switched to https-only)
+# install "pwgen" for randomizing passwords
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		apt-transport-https ca-certificates \
 		pwgen \
@@ -44,17 +72,20 @@ RUN set -ex; \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done; \
 	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/percona.gpg; \
+	command -v gpgconf > /dev/null && gpgconf --kill all || :; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
 RUN echo 'deb https://repo.percona.com/apt jessie main' > /etc/apt/sources.list.d/percona.list
 
+# bashbrew-architectures: amd64 i386
 ENV PERCONA_MAJOR 5.7
 ENV PERCONA_VERSION 5.7.22-22-1.jessie
 
 # the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
 # also, we set debconf keys to make APT a little quieter
-RUN { \
+RUN set -ex; \
+	{ \
 		for key in \
 			percona-server-server/root_password \
 			percona-server-server/root_password_again \
@@ -63,24 +94,26 @@ RUN { \
 		; do \
 			echo "percona-server-server-$PERCONA_MAJOR" "$key" password 'unused'; \
 		done; \
-	} | debconf-set-selections \
-	&& apt-get update \
-	&& apt-get install -y \
+	} | debconf-set-selections; \
+	apt-get update; \
+	apt-get install -y \
 		percona-server-server-$PERCONA_MAJOR=$PERCONA_VERSION \
-	&& rm -rf /var/lib/apt/lists/* \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)
-	&& sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf \
+	sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf; \
 # purge and re-create /var/lib/mysql with appropriate ownership
-	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
-	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
+	rm -rf /var/lib/mysql; \
+	mkdir -p /var/lib/mysql /var/run/mysqld; \
+	chown -R mysql:mysql /var/lib/mysql /var/run/mysqld; \
 # ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 777 /var/run/mysqld \
+	chmod 777 /var/run/mysqld; \
 # comment out a few problematic configuration values
-	&& find /etc/mysql/ -name '*.cnf' -print0 \
+	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \
-		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/' \
+		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/'; \
 # don't reverse lookup hostnames, they are usually another container
-	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
+	echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,27 +1,55 @@
 # vim:set ft=dockerfile:
-FROM debian:jessie
+FROM debian:%%SUITE%%
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
+# https://bugs.debian.org/830696 (apt uses gpgv by default in newer releases, rather than gpg)
+RUN set -ex; \
+	apt-get update; \
+	if ! which gpg; then \
+		apt-get install -y --no-install-recommends gnupg; \
+	fi; \
+# Ubuntu includes "gnupg" (not "gnupg2", but still 2.x), but not dirmngr, and gnupg 2.x requires dirmngr
+# so, if we're not running gnupg 1.x, explicitly install dirmngr too
+	if ! gpg --version | grep -q '^gpg (GnuPG) 1\.'; then \
+		 apt-get install -y --no-install-recommends dirmngr; \
+	fi; \
+	rm -rf /var/lib/apt/lists/*
+
 # add gosu for easy step-down from root
-ENV GOSU_VERSION 1.7
-RUN set -x \
-	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
-	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu \
-	&& gosu nobody true \
-	&& apt-get purge -y --auto-remove ca-certificates wget
+ENV GOSU_VERSION 1.10
+RUN set -ex; \
+	\
+	fetchDeps=' \
+		ca-certificates \
+		wget \
+	'; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends $fetchDeps; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	command -v gpgconf > /dev/null && gpgconf --kill all || :; \
+	rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu nobody true; \
+	\
+	apt-get purge -y --auto-remove $fetchDeps
 
 RUN mkdir /docker-entrypoint-initdb.d
 
-# install "pwgen" for randomizing passwords
 # install "apt-transport-https" for Percona's repo (switched to https-only)
+# install "pwgen" for randomizing passwords
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		apt-transport-https ca-certificates \
 		pwgen \
@@ -44,17 +72,20 @@ RUN set -ex; \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done; \
 	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/percona.gpg; \
+	command -v gpgconf > /dev/null && gpgconf --kill all || :; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
 RUN echo 'deb https://repo.percona.com/apt jessie main' > /etc/apt/sources.list.d/percona.list
 
+# bashbrew-architectures:%%ARCHES%%
 ENV PERCONA_MAJOR %%PERCONA_MAJOR%%
 ENV PERCONA_VERSION %%PERCONA_VERSION%%
 
 # the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
 # also, we set debconf keys to make APT a little quieter
-RUN { \
+RUN set -ex; \
+	{ \
 		for key in \
 			percona-server-server/root_password \
 			percona-server-server/root_password_again \
@@ -63,24 +94,26 @@ RUN { \
 		; do \
 			echo "percona-server-server-$PERCONA_MAJOR" "$key" password 'unused'; \
 		done; \
-	} | debconf-set-selections \
-	&& apt-get update \
-	&& apt-get install -y \
+	} | debconf-set-selections; \
+	apt-get update; \
+	apt-get install -y \
 		percona-server-server-$PERCONA_MAJOR=$PERCONA_VERSION \
-	&& rm -rf /var/lib/apt/lists/* \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)
-	&& sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf \
+	sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf; \
 # purge and re-create /var/lib/mysql with appropriate ownership
-	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
-	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
+	rm -rf /var/lib/mysql; \
+	mkdir -p /var/lib/mysql /var/run/mysqld; \
+	chown -R mysql:mysql /var/lib/mysql /var/run/mysqld; \
 # ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 777 /var/run/mysqld \
+	chmod 777 /var/run/mysqld; \
 # comment out a few problematic configuration values
-	&& find /etc/mysql/ -name '*.cnf' -print0 \
+	find /etc/mysql/ -name '*.cnf' -print0 \
 		| xargs -0 grep -lZE '^(bind-address|log)' \
-		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/' \
+		| xargs -rt -0 sed -Ei 's/^(bind-address|log)/#&/'; \
 # don't reverse lookup hostnames, they are usually another container
-	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
+	echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 

--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,31 @@
 #!/bin/bash
-set -e
+set -eo pipefail
+
+defaultSuite='jessie'
+declare -A suites=(
+#	[5.7]='stretch'
+)
+declare -A dpkgArchToBashbrew=(
+	[amd64]='amd64'
+	[armel]='arm32v5'
+	[armhf]='arm32v7'
+	[arm64]='arm64v8'
+	[i386]='i386'
+	[ppc64el]='ppc64le'
+	[s390x]='s390x'
+)
+
+getRemoteVersion() {
+	local version="$1"; shift # 10.3
+	local suite="$1"; shift # bionic
+	local dpkgArch="$1" shift # arm64
+
+	echo "$(
+		curl -fsSL "https://repo.percona.com/apt/dists/$suite/main/binary-$dpkgArch/Packages" 2>/dev/null  \
+			| tac|tac \
+			| awk -v version="$version" -F ': ' '$1 == "Package" { pkg = $2; next } $1 == "Version" && pkg == "percona-server-server-"version { print $2; exit }'
+	)"
+}
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
@@ -9,19 +35,30 @@ if [ ${#versions[@]} -eq 0 ]; then
 fi
 versions=( "${versions[@]%/}" )
 
-packagesUrl='http://repo.percona.com/apt/dists/jessie/main/binary-amd64/Packages'
-packages="$(echo "$packagesUrl" | sed -r 's/[^a-zA-Z.-]+/-/g')"
-curl -sSL "${packagesUrl}.gz" | gunzip > "$packages"
-
+#	fullVersion="$(grep -m1 -A10 "^Package: percona-server-server-$version\$" "$packages" | grep -m1 '^Version: ' | cut -d' ' -f2)"
 for version in "${versions[@]}"; do
-	fullVersion="$(grep -m1 -A10 "^Package: percona-server-server-$version\$" "$packages" | grep -m1 '^Version: ' | cut -d' ' -f2)"
+	suite="${suites[$version]:-$defaultSuite}"
+	fullVersion="$(getRemoteVersion "$version" "$suite" 'amd64')"
+	if [ -z "$fullVersion" ]; then
+		echo >&2 "warning: cannot find $version in $suite"
+		continue
+	fi
+
+	arches=
+	sortedArches="$(echo "${!dpkgArchToBashbrew[@]}" | xargs -n1 | sort | xargs)"
+	for arch in $sortedArches; do
+		if ver="$(getRemoteVersion "$version" "$suite" "$arch")" && [ -n "$ver" ]; then
+			arches="$arches ${dpkgArchToBashbrew[$arch]}"
+		fi
+	done
+
 	(
 		set -x
-		sed '
-			s/%%PERCONA_MAJOR%%/'"$version"'/g;
-			s/%%PERCONA_VERSION%%/'"$fullVersion"'/g;
-		' Dockerfile.template > "$version/Dockerfile"
+		sed \
+			-e 's/%%PERCONA_MAJOR%%/'"$version"'/g' \
+			-e 's/%%PERCONA_VERSION%%/'"$fullVersion"'/g' \
+			-e 's!%%SUITE%%!'"$suite"'!g' \
+			-e 's!%%ARCHES%%!'"$arches"'!g' \
+			Dockerfile.template > "$version/Dockerfile"
 	)
 done
-
-rm "$packages"


### PR DESCRIPTION
Also sync updates from MariaDB Dockerfile in preparation for stretch update.  Related #54.

```diff
$ diff --unified ../official-images/library/percona <(./generate-stackbrew-library.sh)
--- ../official-images/library/percona	2018-07-24 13:57:16.697887586 -0700
+++ /dev/fd/63	2018-07-26 14:23:55.352247385 -0700
@@ -1,17 +1,20 @@
-# this file is generated via https://github.com/docker-library/percona/blob/11b6067c39e69db2c71f6c43edb902690dc5a132/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/percona/blob/2bc351a6c89c243851efc828d7ec19a21663df80/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/percona.git
 
-Tags: 5.7.22, 5.7, 5, latest
-GitCommit: 01c136a28e68649b02fc2e00a580067e97f763c7
+Tags: 5.7.22-jessie, 5.7-jessie, 5-jessie, jessie, 5.7.22, 5.7, 5, latest
+Architectures: amd64, i386
+GitCommit: 2bc351a6c89c243851efc828d7ec19a21663df80
 Directory: 5.7
 
-Tags: 5.6.40, 5.6
-GitCommit: 24e0d02a91dd7880e2ac7991818887fd7df1303a
+Tags: 5.6.40-jessie, 5.6-jessie, 5.6.40, 5.6
+Architectures: amd64, i386
+GitCommit: 2bc351a6c89c243851efc828d7ec19a21663df80
 Directory: 5.6
 
-Tags: 5.5.60, 5.5
-GitCommit: 12afad5976f769f545bb9f85583e40e84109b80c
+Tags: 5.5.60-jessie, 5.5-jessie, 5.5.60, 5.5
+Architectures: amd64, i386
+GitCommit: 2bc351a6c89c243851efc828d7ec19a21663df80
 Directory: 5.5
```